### PR TITLE
Resolved the bug by not saving the user if OTP sending fails

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -58,8 +58,8 @@ const resendOTP = async (req, res)=>{
     const newExpiry = new Date(Date.now()+5*60*1000);
     user.otp = newOTP;
     user.otpExpiresAt = newExpiry;
-    await user.save();
     await sendOTP(email, newOTP);
+    await user.save();
     res.status(StatusCodes.OK).json({success : true, msg :`New OTP sent to ${email}`});
 }
 


### PR DESCRIPTION
The OTP sending code snippet line is shifted above line of saving or creating user. Just by chance if OTP sending fails then it will throw error resulting in not updating the otp field of user in database. Before this, the user was getting updated and then otp sending was initiated, this might lead to a problem that otp got updated in user's document but OTP sending fails due to internal server error.